### PR TITLE
Fix open_url call (change User-Agent)

### DIFF
--- a/lookup_plugins/rhsecapi.py
+++ b/lookup_plugins/rhsecapi.py
@@ -39,7 +39,8 @@ class LookupModule(LookupBase):
         try:
             response = open_url(url,
                                 validate_certs=validate_certs,
-                                use_proxy=use_proxy)
+                                use_proxy=use_proxy,
+                                http_agent='ansible-httpget')
             return response.read()
         except HTTPError as e:
             raise AnsibleError("Received HTTP error for %s : %s" %


### PR DESCRIPTION
Looks like urllib calls are blocked by CDN. It can be checked by curl"
curl -H 'User-Agent: Python-urllib/3.7' https://access.redhat.com/labs/securitydataapi/cve/CVE-2011-3597.json 
I found similar bug in ansible's repository: https://github.com/ansible/ansible/pull/56635
So this fix will help until it fixed in ansible repository.

HTTP stream dump:
GET /labs/securitydataapi/cve/CVE-2011-3597.json HTTP/1.1
Host: access.redhat.com
Connection: keep-alive
Accept-Encoding: gzip, deflate
Accept: */*
User-Agent: python-requests/2.19.1

HTTP/1.1 301 Moved Permanently
Server: AkamaiGHost
Content-Length: 0
Location: https://access.redhat.com/labs/securitydataapi/cve/CVE-2011-3597.json
Date: Tue, 13 Aug 2019 11:54:02 GMT
Connection: keep-alive